### PR TITLE
Add escaping of js translation version

### DIFF
--- a/app/code/Magento/Translation/view/base/templates/translate.phtml
+++ b/app/code/Magento/Translation/view/base/templates/translate.phtml
@@ -28,7 +28,7 @@
 
                 <?php $version = sha1($block->getTranslationFileTimestamp() . $block->getTranslationFilePath()); ?>
 
-                if (versionObj.version !== '<?php /* @noEscape */ echo $version ?>') {
+                if (versionObj.version !== '<?php $block->escapeJsQuote($version) ?>') {
                     dependencies.push(
                         'text!<?php /* @noEscape */ echo Magento\Translation\Model\Js\Config::DICTIONARY_FILE_NAME ?>'
                     );
@@ -44,7 +44,7 @@
                             $.localStorage.set(
                                 'mage-translation-file-version',
                                 {
-                                    version: '<?php /* @noEscape */ echo $version ?>'
+                                    version: '<?php $block->escapeJsQuote($version) ?>'
                                 }
                             );
                         } else {


### PR DESCRIPTION
As it was discussed in https://github.com/magento/magento2/pull/10378#discussion_r136984136 - we need to escape js translation version.

**Steps to reproduce:**
1. Put following code to getTranslationFileVersion method (directly or via plugin):
```php
return "' || alert(1) || '";
```
2. Go to any page

**Actual result:**
1. Alert with message 1 is shown

**Expected result:**
1. Alert mustn't be shown